### PR TITLE
Debug image display in Stripe web app

### DIFF
--- a/next-ecms-demo/app/site-sections.tsx
+++ b/next-ecms-demo/app/site-sections.tsx
@@ -11,6 +11,7 @@ export function HomeHero() {
           src="/images/hero-1.jpg"
           alt="Caring at home"
           fill
+          sizes="100vw"
           priority
           className="object-cover"
         />


### PR DESCRIPTION
Add `sizes="100vw"` to the hero `Image` component to ensure it renders reliably when using `fill`.

When using `fill` on a Next.js `Image` component, the `sizes` attribute is often required for correct rendering and layout computation, as Next.js may not render or mis-compute the layout without it.

---
<a href="https://cursor.com/background-agent?bcId=bc-e483a87a-5ea7-4c2a-8722-0c5b30ccb6e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e483a87a-5ea7-4c2a-8722-0c5b30ccb6e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

